### PR TITLE
Feature & FIx : retry 기능 추가 및 JPA 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-
     // ssr
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -49,7 +47,12 @@ dependencies {
     // spock
     implementation group: 'org.spockframework', name: 'spock-spring', version: '2.4-M1-groovy-4.0'
 
+    // db
+    // mariadb
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    testImplementation 'org.testcontainers:mariadb:1.18.0'
 
+    // h2  -> 운영 디비에서는 삭제
     runtimeOnly 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok'
@@ -57,8 +60,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.30' //테스트 환경에서 주입
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'	//테스트환경의 어노테이션 주입
 
-
-
+    // 추후 삭제 예정
     // dev tools only
     compileOnly "org.springframework.boot:spring-boot-devtools"
 
@@ -66,7 +68,6 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
 
     // aws
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
@@ -78,11 +79,21 @@ dependencies {
     //secure - jdbc session
     implementation 'org.springframework.session:spring-session-jdbc'
 
+    // spring retry
+    implementation 'org.springframework.retry:spring-retry:2.0.3'
+
+    // spring aop
+    implementation 'spring-boot-starter-aop:spring-aspects:6.0.11'
+
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     testImplementation 'org.springframework.security:spring-security-test'
 
     // oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // mockWebServer
+    testImplementation('com.squareup.okhttp3:okhttp:4.10.0')
+    testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
 
 }
 

--- a/src/main/java/co/pickcake/PickCakeApplication.java
+++ b/src/main/java/co/pickcake/PickCakeApplication.java
@@ -5,6 +5,8 @@ import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolator
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
 
 @SpringBootApplication
 public class PickCakeApplication {

--- a/src/main/java/co/pickcake/aop/datetime/AuditOnTime.java
+++ b/src/main/java/co/pickcake/aop/datetime/AuditOnTime.java
@@ -1,0 +1,22 @@
+package co.pickcake.aop.datetime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditOnTime {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/co/pickcake/apiutil/WebClientUtil.java
+++ b/src/main/java/co/pickcake/apiutil/WebClientUtil.java
@@ -29,7 +29,12 @@ public class WebClientUtil {
                 .retrieve()
                 .onStatus(
                         HttpStatus.INTERNAL_SERVER_ERROR::equals,
-                        response -> response.bodyToMono(String.class).map(Exception::new))
+                        response -> response.bodyToMono(String.class).map(Exception::new)
+                )
+                .onStatus(
+                        HttpStatus.GATEWAY_TIMEOUT::equals,
+                        response -> response.bodyToMono(String.class).map(Exception::new)
+                )
                 .onStatus(
                         HttpStatus.BAD_REQUEST::equals,
                         response -> response.bodyToMono(String.class).map(Exception::new))

--- a/src/main/java/co/pickcake/authdomain/entity/Member.java
+++ b/src/main/java/co/pickcake/authdomain/entity/Member.java
@@ -1,13 +1,18 @@
 package co.pickcake.authdomain.entity;
 
+import co.pickcake.aop.datetime.AuditOnTime;
 import co.pickcake.common.entity.Address;
+import co.pickcake.recommand.entity.Heart;
 import co.pickcake.shopdomain.entity.Shop;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity @Getter
-public class Member {
+public class Member extends AuditOnTime {
 
     @Id @GeneratedValue
     @Column(name = "member_id")
@@ -18,6 +23,10 @@ public class Member {
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "member")
     private Shop shop;
+
+    @Column(name="PROVIDER_TYPE", length = 20)
+    @Enumerated(EnumType.STRING)
+    private ProviderType providerType;
 
     @Embedded
     private Address address;
@@ -35,14 +44,17 @@ public class Member {
         this.password = password;
     }
 
+    public void setProviderType(ProviderType providerType) {
+        this.providerType = providerType;
+    }
     /* api */
     /* 좋아요 relation 에 대한 연관 관계를 단방향 매핑으로 수정
      * 양방향으로 매핑할 경우, 얻을 수 있는 장점은 유저가 삭제될 때, 좋아요 정보도 날릴 수 있다는 점인데,
      * 삭제는 별도 dml로 관리하는 것이 JPA 쿼리 예측에 편하고 데이터 활용성을 위해 좋아요 relation 을 누적하기로 함.
      * 좋아요 relation에 유효하지 않은 member_id 가 있을 수 있다는 점만 entity 에 명시하도록 변경.
-     * @OneToMany(mappedBy = "member")
-     * private List<Heart> hearts = new ArrayList<>();
     * */
+    @OneToMany(mappedBy = "member")
+    private List<Heart> hearts = new ArrayList<>();
     /* 연관 관계 편의 메서드 */
 
     /* 생성 편의 메서드 */
@@ -56,6 +68,7 @@ public class Member {
         }
         member.setUserID(userId);
         member.setAddress(Address.createAddress(city, street, zipcode));
+        member.setProviderType(ProviderType.NATIVE);
         return member;
     }
     public static Member createMember(String username, String userId, String password) {
@@ -67,8 +80,24 @@ public class Member {
             member.setUsername(username);
         }
         member.setUserID(userId);
+        member.setProviderType(ProviderType.NATIVE);
         return member;
     }
+    /* 3rd-party social login only */
+    public static Member createMember(String username, String userId, String password, ProviderType providerType) {
+        Member member = new Member();
+        member.setPassword(password);
+        if ( username == null) {
+            member.setUsername(userId);
+        } else {
+            member.setUsername(username);
+        }
+        member.setUserID(userId);
+        member.setProviderType(providerType);
+        return member;
+    }
+
+
     public void changePassword(String newPassword) {
         password = newPassword;
     }

--- a/src/main/java/co/pickcake/config/JpaConfig.java
+++ b/src/main/java/co/pickcake/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package co.pickcake.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/co/pickcake/config/RetryConfig.java
+++ b/src/main/java/co/pickcake/config/RetryConfig.java
@@ -1,0 +1,30 @@
+package co.pickcake.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+
+//    @Bean
+//    public RetryTemplate retryTemplate() {
+//        RetryTemplate retryTemplate = new RetryTemplate();
+//
+//        FixedBackOffPolicy fixedBackOffPolicy = new FixedBackOffPolicy();
+//        fixedBackOffPolicy.setBackOffPeriod(2000l);
+//        retryTemplate.setBackOffPolicy(fixedBackOffPolicy);
+//
+//        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+//        retryPolicy.setMaxAttempts(2);
+//        retryTemplate.setRetryPolicy(retryPolicy);
+//
+//        return retryTemplate;
+//    }
+
+}
+/* web client 쓸 경우 필요하지 않아 보임 */

--- a/src/main/java/co/pickcake/config/WebClientConfig.java
+++ b/src/main/java/co/pickcake/config/WebClientConfig.java
@@ -33,7 +33,7 @@ public class WebClientConfig {
         return ConnectionProvider.builder("http-pool")
                 .maxConnections(100)
                 .pendingAcquireTimeout(Duration.ofMillis(0))
-                .pendingAcquireMaxCount(-1)
+                .pendingAcquireMaxCount(2)
                 .maxIdleTime(Duration.ofMillis(1000L))
                 .build();
     }

--- a/src/main/java/co/pickcake/mapapi/response/KaKaoDocumentResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/KaKaoDocumentResponse.java
@@ -20,4 +20,14 @@ public class KaKaoDocumentResponse {
 
     @JsonProperty("distance")
     private double distance;
+
+    public static KaKaoDocumentResponse create(String  placeName, String addressName, Double latitude, Double longitude, Double distance) {
+        KaKaoDocumentResponse response = new KaKaoDocumentResponse();
+        response.placeName = placeName;
+        response.addressName = addressName;
+        response.latitude = latitude;
+        response.longitude = longitude;
+        response.distance = distance;
+        return response;
+    }
 }

--- a/src/main/java/co/pickcake/mapapi/response/KaKaoMapApiResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/KaKaoMapApiResponse.java
@@ -14,4 +14,12 @@ public class KaKaoMapApiResponse {
     private KaKaoMetaResponse metaResponse;
     @JsonProperty("documents")
     private List<KaKaoDocumentResponse> documentResponses;
+
+    public static KaKaoMapApiResponse create(HttpStatus status, KaKaoMetaResponse meta, List<KaKaoDocumentResponse> documents) {
+        KaKaoMapApiResponse response = new KaKaoMapApiResponse();
+        response.metaResponse = meta;
+        response.documentResponses = documents;
+        response.status = status;
+        return response;
+    }
 }

--- a/src/main/java/co/pickcake/mapapi/response/KaKaoMetaResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/KaKaoMetaResponse.java
@@ -8,4 +8,10 @@ public class KaKaoMetaResponse {
     @JsonProperty("total_count")
     private Integer totalCount;
 
+    public static KaKaoMetaResponse create(Integer totalCount) {
+        KaKaoMetaResponse meta = new KaKaoMetaResponse();
+        meta.totalCount = totalCount;
+        return meta;
+    }
+
 }

--- a/src/main/java/co/pickcake/mapapi/response/NaverMapApiResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/NaverMapApiResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
+import javax.print.attribute.standard.MediaSize;
 import java.util.List;
 
 @Data
@@ -11,12 +12,17 @@ public class NaverMapApiResponse {
 
     @JsonProperty("status")
     private HttpStatus status;
-
     @JsonProperty("meta")
     private NaverMetaResponse metaResponse;
-
     @JsonProperty("addresses")
     private List<NaverMapDocumentResponse> documentResponses;
 
+    public static NaverMapApiResponse create(HttpStatus status, NaverMetaResponse meta, List<NaverMapDocumentResponse> documents) {
+        NaverMapApiResponse response = new NaverMapApiResponse();
+        response.status= status;
+        response.metaResponse = meta;
+        response.documentResponses = documents;
+        return  response;
+    }
 
 }

--- a/src/main/java/co/pickcake/mapapi/response/NaverMapDocumentResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/NaverMapDocumentResponse.java
@@ -10,29 +10,30 @@ public class NaverMapDocumentResponse {
 
     @JsonProperty("roadAddress")
     private String roadAddress;
-
     @JsonProperty("jibunAddress")
     private String jibunAddress;
-
-//    @JsonProperty("addressElements")
-//    private List<NaverMapDto> elements;
-
     @JsonProperty("y")
     private String latitude;
-
     @JsonProperty("x")
     private String longitude;
-
     @JsonProperty("distance")
     private double distance;
-
+    //    @JsonProperty("addressElements")
+//    private List<NaverMapDto> elements;
     public static class NaverMapDto {
-
         @JsonProperty("types")
         private List<String> types;
-
         @JsonProperty("longName")
         private String longName;
-
+    }
+    public static NaverMapDocumentResponse create(String roadAddress, String jibunAddress,
+                                                  String latitude, String longitude, Double distance) {
+        NaverMapDocumentResponse document = new NaverMapDocumentResponse();
+        document.roadAddress = roadAddress;
+        document.jibunAddress = jibunAddress;
+        document.latitude = latitude;
+        document.longitude = longitude;
+        document.distance = distance;
+        return document;
     }
 }

--- a/src/main/java/co/pickcake/mapapi/response/NaverMetaResponse.java
+++ b/src/main/java/co/pickcake/mapapi/response/NaverMetaResponse.java
@@ -13,4 +13,11 @@ public class NaverMetaResponse {
 
     @JsonProperty("count")
     private Integer count;
+    public static NaverMetaResponse create(Integer totalCount, Integer page, Integer count) {
+        NaverMetaResponse meta = new NaverMetaResponse();
+        meta.totalCount = totalCount;
+        meta.page = page;
+        meta.count = count;
+        return meta;
+    }
 }

--- a/src/main/java/co/pickcake/mapapi/service/BaseUriBuilder.java
+++ b/src/main/java/co/pickcake/mapapi/service/BaseUriBuilder.java
@@ -1,0 +1,10 @@
+package co.pickcake.mapapi.service;
+
+import co.pickcake.common.entity.Address;
+
+import java.net.URI;
+
+public interface BaseUriBuilder {
+    public URI builderUrlByAddress(Address address);
+
+}

--- a/src/main/java/co/pickcake/mapapi/service/KaKaoUriBuilderService.java
+++ b/src/main/java/co/pickcake/mapapi/service/KaKaoUriBuilderService.java
@@ -12,11 +12,12 @@ import java.net.URI;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KaKaoUriBuilderService {
+public class KaKaoUriBuilderService implements BaseUriBuilder  {
 
     /* TODO api url 관리 방법 고민, 지금은 서비스 규모가 크지 않아 static final 로 관리 */
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    @Override
     public URI builderUrlByAddress(Address address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
         uriBuilder.queryParam("query", address.toSimpleString());

--- a/src/main/java/co/pickcake/mapapi/service/NaverUriBuilderService.java
+++ b/src/main/java/co/pickcake/mapapi/service/NaverUriBuilderService.java
@@ -11,8 +11,10 @@ import java.net.URI;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class NaverUriBuilderService {
+public class NaverUriBuilderService implements BaseUriBuilder {
     private static final String NAVER_LOCAL_SEARCH_ADDRESS_URL = "https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode";
+
+    @Override
     public URI builderUrlByAddress(Address address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(NAVER_LOCAL_SEARCH_ADDRESS_URL);
         uriBuilder.queryParam("query", address.toSimpleString());

--- a/src/main/java/co/pickcake/reservedomain/entity/ReserveInfo.java
+++ b/src/main/java/co/pickcake/reservedomain/entity/ReserveInfo.java
@@ -1,5 +1,6 @@
 package co.pickcake.reservedomain.entity;
 
+import co.pickcake.aop.datetime.AuditOnTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -7,12 +8,15 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReserveInfo {
+public class ReserveInfo extends AuditOnTime {
 
     @Id
     @GeneratedValue

--- a/src/main/java/co/pickcake/reservedomain/entity/item/EventCakeCategory.java
+++ b/src/main/java/co/pickcake/reservedomain/entity/item/EventCakeCategory.java
@@ -1,6 +1,7 @@
 package co.pickcake.reservedomain.entity.item;
 
 
+import co.pickcake.aop.datetime.AuditOnTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class EventCakeCategory {
+public class EventCakeCategory extends AuditOnTime {
 
     @Id
     @GeneratedValue

--- a/src/main/java/co/pickcake/shopdomain/entity/Shop.java
+++ b/src/main/java/co/pickcake/shopdomain/entity/Shop.java
@@ -1,5 +1,6 @@
 package co.pickcake.shopdomain.entity;
 
+import co.pickcake.aop.datetime.AuditOnTime;
 import co.pickcake.authdomain.entity.Member;
 import co.pickcake.common.entity.Address;
 import co.pickcake.reservedomain.entity.ReserveInfo;
@@ -10,14 +11,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Shop {
+public class Shop extends AuditOnTime {
 
     @Id @GeneratedValue
     @Column(name = "shop_id")
@@ -48,6 +48,9 @@ public class Shop {
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Instagram instagram;
+
+
+
 
     /* 수정 메서드 */
     public void setSiteUrl(String siteUrl) {

--- a/src/test/java/co/pickcake/imagedomain/service/ImageStoreServiceTest.java
+++ b/src/test/java/co/pickcake/imagedomain/service/ImageStoreServiceTest.java
@@ -1,30 +1,49 @@
 package co.pickcake.imagedomain.service;
 
+import co.pickcake.imagedomain.entity.CakeImages;
 import co.pickcake.imagedomain.entity.ImageFile;
 import co.pickcake.imagedomain.repository.CakeImageRepository;
+import co.pickcake.reservedomain.entity.item.Cake;
+import co.pickcake.testconfig.TestDataItem;
+import co.pickcake.util.TestInitDB;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Transactional
-
+@AutoConfigureMockMvc
 class ImageStoreServiceTest {
 
 
     @Autowired ImageStoreService imageStoreService;
     @Autowired CakeImageRepository cakeImageRepository;
+    @Autowired TestInitDB testInitDB;
 
     @Test
-    @DisplayName("이미지 저장 테스트 1")
+    @DisplayName("기능 테스트[success]: 이미지 메타데이터가 정상적으로 저장되는 지 확인")
+    @Transactional
     public void saveImageFile_v1() {
+        //given
+        TestDataItem testDataItem = testInitDB.dbInitWithSingleItem();
+        Cake cake1 = (Cake) testDataItem.getItems().get("cake1");
+        CakeImages cakeImages = cake1.getCakeImages();
+        ImageFile profileImage = cakeImages.getProfileImage();
+        //when
+        ImageFile savedImageFile = imageStoreService.findById(profileImage.getId());
+        //then
+        Assertions.assertThat(cakeImages).isNotNull();
 
-//        ImageFile imageFile = imageStoreService.storeFile();
+        Assertions.assertThat(profileImage).isNotNull();
+        Assertions.assertThat(profileImage.getId()).isEqualTo(savedImageFile.getId());
+        Assertions.assertThat(profileImage.getStoreFileName()).isEqualTo(savedImageFile.getStoreFileName());
+
+        Assertions.assertThat(profileImage.getStoreFileName()).isNotEqualTo(profileImage.getUploadFileName());
     }
 
 

--- a/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceMockTest.java
+++ b/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceMockTest.java
@@ -1,0 +1,60 @@
+package co.pickcake.mapapi.service;
+
+import co.pickcake.common.entity.Address;
+import co.pickcake.mapapi.response.KaKaoDocumentResponse;
+import co.pickcake.mapapi.response.KaKaoMapApiResponse;
+import co.pickcake.mapapi.response.KaKaoMetaResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MapSearchApiServiceMockTest {
+    @Autowired
+    private MapSearchApiService mapSearchApiService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @DisplayName("v1 api[success]: 카카오 Native RestTemplate  map geo search ")
+    void v1kakaoWithNativeRestTemplate() {
+        //given
+        Address address = Address.createAddress("서울", "동호로 249", "");
+
+        //when
+        KaKaoMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateNativeOnKAKAO(address);
+        List<KaKaoDocumentResponse> documents = response.getDocumentResponses();
+        KaKaoMetaResponse meta = response.getMetaResponse();
+
+        for (KaKaoDocumentResponse items: documents) {
+            System.out.println("items = " + items);
+        }
+
+        //then
+        Assertions.assertThat(documents).isNotNull();
+        Assertions.assertThat(meta).isNotNull();
+
+        Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
+        Assertions.assertThat(documents.getFirst().getLatitude()).isNotEqualTo(0.0);
+        Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
+    }
+
+}

--- a/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceRetryTest.java
+++ b/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceRetryTest.java
@@ -1,0 +1,151 @@
+package co.pickcake.mapapi.service;
+
+import co.pickcake.common.entity.Address;
+import co.pickcake.mapapi.response.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MapSearchApiServiceRetryTest {
+
+    @Autowired private MapSearchApiService mapSearchApiService;
+    @Autowired private MockMvc mockMvc;
+
+    private MockWebServer mockWebServer;
+    private MockWebUriBuilder mockWebUriBuilder;
+
+    /* TODO LAZY MOCKBEAN 검토 필요 */
+    @MockBean
+    private KaKaoUriBuilderService kaKaoUriBuilderService;
+    @MockBean
+    private NaverUriBuilderService naverUriBuilderService;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockWebServer = new MockWebServer();
+        try {
+            mockWebServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        int port = mockWebServer.getPort();
+        System.out.println("Mock Web Server port = " + port);
+        HttpUrl url = mockWebServer.url("/");
+        System.out.println("url = " + url);
+        mockWebUriBuilder = new MockWebUriBuilder(); /* 별도로 쿼리 생성해야한다면 이 부분 반드시 바꿀 것 */
+        mockWebUriBuilder.LOCAL_REQEUST_GATE_WAY = mockWebServer.url("/").uri().toString();
+    }
+    @AfterEach
+    void tearDown() {
+        try {
+            mockWebServer.shutdown();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    /* TODO 3rd-party 마다 MockMvc class 따로 생성해야할지는 테스트 스펙에 따라 달려 있음.
+    *   지금은 예외처리 부분만 테스트하고 있기 때문에 Mock class 하나로 모두 바꿔치기 가능하지만
+    *   기능 테스트 단위로 넘어갈 경우, ToOne 으로 생성 필요.
+    *   생각했던 것 보다 코드 양이 자꾸 늘어나서 더 최적화된 보일러 플레이트 코드 필요 */
+    /* SEE MockWebUriBuilder at BeforeEach */
+    public static class MockWebUriBuilder implements BaseUriBuilder  {
+        public String LOCAL_REQEUST_GATE_WAY = "http://localhost";
+        @Override
+        public URI builderUrlByAddress(Address address) {
+            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(LOCAL_REQEUST_GATE_WAY);
+            uriBuilder.queryParam("query", address.toSimpleString());
+            URI uri = uriBuilder.build().encode().toUri();
+            return uri;
+        }
+    }
+    public static class MockWebResponseBuilder {
+
+        public static KaKaoMapApiResponse createKakaoResponse() {
+            KaKaoMetaResponse metaExpected = KaKaoMetaResponse.create(1);
+            KaKaoDocumentResponse documentExpected = KaKaoDocumentResponse.create("신라호텔",
+                    "서울 동호로 249", 100D, 37D, 0D);
+            ArrayList<KaKaoDocumentResponse> documentsExpected = new ArrayList<>();
+            documentsExpected.add(documentExpected);
+            return KaKaoMapApiResponse.create(HttpStatus.OK, metaExpected, documentsExpected);
+        }
+
+        public static NaverMapApiResponse createNaverResponse() {
+            NaverMetaResponse metaExpected = NaverMetaResponse.create(1, 1, 1);
+            NaverMapDocumentResponse documentExpected = NaverMapDocumentResponse.create("동호로 249",
+                    "서울시 중구", "100", "30", 0D);
+            ArrayList<NaverMapDocumentResponse> documentsExpected = new ArrayList<>();
+            documentsExpected.add(documentExpected);
+            return NaverMapApiResponse.create(HttpStatus.OK, metaExpected, documentsExpected);
+        }
+    }
+    /* SEE MockWebUriBuilder at BeforeEach */
+    @Test
+    @DisplayName("v2 api[success]: 예외처리 카카오 Intercept RestTemplate map geo search Retry Test")
+    void v2kakaoWtihInterceptRestTemplate() throws JsonProcessingException {
+        //given
+        KaKaoMapApiResponse responseExpected = MockWebResponseBuilder.createKakaoResponse();
+        Address address = Address.createAddress("서울", "동호로 249", "");
+        Mockito.when(kaKaoUriBuilderService.builderUrlByAddress(address))
+                .thenReturn(mockWebUriBuilder.builderUrlByAddress(address));
+        //when
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                        .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseExpected)));
+        KaKaoMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateInterceptOnKAKAO(address);
+        //then
+        Assertions.assertThat(response).isNotNull(); // retry 요청 횟수가 2라면 반드시 성공해야함.
+        Assertions.assertThat(response.getMetaResponse()).isNotNull();
+        Assertions.assertThat(response.getMetaResponse().getTotalCount()).isEqualTo(1);
+        Assertions.assertThat(response.getDocumentResponses().size()).isEqualTo(1);
+        Assertions.assertThat(response.getDocumentResponses().getFirst().getLatitude()).isEqualTo(100D);
+        Assertions.assertThat(response.getDocumentResponses().getFirst().getLongitude()).isEqualTo(37D);
+    }
+    @Test
+    @DisplayName("v2 api[success]: 예외처리 네이버 Intercept RestTemplate map geo search Retry Test ")
+    void v2naverWtihInterceptRestTemplate() throws JsonProcessingException {
+        //given
+        NaverMapApiResponse responseExpected = MockWebResponseBuilder.createNaverResponse();
+        Address address = Address.createAddress("서울", "동호로 249", "");
+        Mockito.when(naverUriBuilderService.builderUrlByAddress(address))
+                .thenReturn(mockWebUriBuilder.builderUrlByAddress(address));
+        //when
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseExpected)));
+
+        NaverMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateInterceptOnNAVER(address);
+        //then
+        Assertions.assertThat(response).isNotNull(); // retry 요청 횟수가 2라면 반드시 성공해야함.
+        Assertions.assertThat(response.getMetaResponse()).isNotNull();
+        Assertions.assertThat(response.getMetaResponse().getTotalCount()).isEqualTo(1);
+        Assertions.assertThat(response.getDocumentResponses().size()).isEqualTo(1);
+        Assertions.assertThat(response.getDocumentResponses().getFirst().getLatitude()).isEqualTo("100");
+        Assertions.assertThat(response.getDocumentResponses().getFirst().getLongitude()).isEqualTo("30");
+    }
+
+}

--- a/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceTest.java
+++ b/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceTest.java
@@ -197,6 +197,15 @@ class MapSearchApiServiceTest {
         Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
     }
     @Test
+    @DisplayName("api 예외처리 [fail]: address 값이 null 로 들어갔을 떄")
+    public void searchGeoWithPreDefinedFail() {
+        // given
+        // when
+        //then
+        Assertions.assertThatThrownBy(()-> mapSearchApiService.searchGeoOnKAKAO(null)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
     @DisplayName("Currently used api[success]: 네이버 WebClient native map geo search")
     void searchGeoWithWebClientNaver() {
         // given
@@ -216,6 +225,8 @@ class MapSearchApiServiceTest {
 
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
     }
+
+
 
 
 

--- a/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceTest.java
+++ b/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceTest.java
@@ -11,15 +11,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-
-/* TODO  MockMvc API 요청 서버 만들기, api key도 테스트에서 계속 사용되는 게 불편하고,  테스트 돌리다가 api 일일 요청량 넘음 ;; */
 @SpringBootTest
 @AutoConfigureMockMvc
 class MapSearchApiServiceTest {
     /*
     * 해당 테스트 클래스는 성능 테스트, 부하테스트 등 다양하게 사용되기 때문에 수정을 최소한으로 할것
     * 또한 만약 이곳에서 에러가 발생한다면 디펜던시, 버전 체크, Dto 변경한 건 없었는지 확인 할 것
-    * 추후 목 서버 추가 예정
     * */
 
     @Autowired
@@ -48,42 +45,36 @@ class MapSearchApiServiceTest {
     void v1kakaoWithNativeRestTemplate() {
         //given
         Address address = Address.createAddress("서울", "동호로 249", "");
-
         //when
         KaKaoMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateNativeOnKAKAO(address);
         List<KaKaoDocumentResponse> documents = response.getDocumentResponses();
         KaKaoMetaResponse meta = response.getMetaResponse();
-
         for (KaKaoDocumentResponse items: documents) {
             System.out.println("items = " + items);
         }
-
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
         Assertions.assertThat(documents.getFirst().getLatitude()).isNotEqualTo(0.0);
         Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
     }
+
     @Test
     @DisplayName("v2 api[success]: 카카오 Intercept RestTemplate map geo search ")
     void v2kakaoWtihInterceptRestTemplate() {
+        //given
         Address address = Address.createAddress("서울", "동호로 249", "");
-
         //when
         KaKaoMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateInterceptOnKAKAO(address);
         List<KaKaoDocumentResponse> documents = response.getDocumentResponses();
         KaKaoMetaResponse meta = response.getMetaResponse();
-
         for (KaKaoDocumentResponse items: documents) {
             System.out.println("items = " + items);
         }
-
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
         Assertions.assertThat(documents.getFirst().getLatitude()).isNotEqualTo(0.0);
         Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
@@ -98,14 +89,12 @@ class MapSearchApiServiceTest {
         KaKaoMapApiResponse response = mapSearchApiService.searchGeoWithWebClientNativeOnKAKAO(address);
         KaKaoMetaResponse meta = response.getMetaResponse();
         List<KaKaoDocumentResponse> documents = response.getDocumentResponses();
-
         for (KaKaoDocumentResponse document: documents) {
             System.out.println("document = " + document);
         }
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
         Assertions.assertThat(documents.getFirst().getLatitude()).isNotEqualTo(0.0);
         Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
@@ -126,32 +115,44 @@ class MapSearchApiServiceTest {
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
         Assertions.assertThat(documents.getFirst().getLatitude()).isNotEqualTo(0.0);
         Assertions.assertThat(documents.getFirst().getLongitude()).isNotEqualTo(0.0);
+    }
+    @Test
+    @DisplayName("v2 api[success]: 네이버 Native RestTemplate map geo search ")
+    void v1NaverWithNativeRestTemplate() {
+        //given
+        Address address = Address.createAddress("서울", "동호로 249", "");
+        //when
+        NaverMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateNativeOnNAVER(address);
+        List<NaverMapDocumentResponse> documents = response.getDocumentResponses();
+        NaverMetaResponse meta = response.getMetaResponse();
+        for (NaverMapDocumentResponse items: documents) {
+            System.out.println("items = " + items);
+        }
+        //then
+        Assertions.assertThat(documents).isNotNull();
+        Assertions.assertThat(meta).isNotNull();
+        Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("v2 api[success]: 네이버 Intercept RestTemplate map geo search ")
     void v2naverWtihInterceptRestTemplate() {
+        //given
         Address address = Address.createAddress("서울", "동호로 249", "");
-
         //when
         NaverMapApiResponse response = mapSearchApiService.searchGeoWithRestTemplateInterceptOnNAVER(address);
         List<NaverMapDocumentResponse> documents = response.getDocumentResponses();
         NaverMetaResponse meta = response.getMetaResponse();
-
         for (NaverMapDocumentResponse items: documents) {
             System.out.println("items = " + items);
         }
-
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
-
     }
 
     @Test
@@ -167,11 +168,9 @@ class MapSearchApiServiceTest {
         for (NaverMapDocumentResponse items: documents) {
             System.out.println("items = " + items);
         }
-
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
     }
 
@@ -214,7 +213,6 @@ class MapSearchApiServiceTest {
         NaverMapApiResponse response = mapSearchApiService.searchGeoOnNAVER(address);
         List<NaverMapDocumentResponse> documents = response.getDocumentResponses();
         NaverMetaResponse meta = response.getMetaResponse();
-
         for (NaverMapDocumentResponse items: documents) {
             System.out.println("items = " + items);
         }
@@ -222,15 +220,6 @@ class MapSearchApiServiceTest {
         //then
         Assertions.assertThat(documents).isNotNull();
         Assertions.assertThat(meta).isNotNull();
-
         Assertions.assertThat(meta.getTotalCount()).isEqualTo(1);
     }
-
-
-
-
-
-
-
-
 }

--- a/src/test/java/co/pickcake/shopdomain/repository/ShopRepositoryTest.java
+++ b/src/test/java/co/pickcake/shopdomain/repository/ShopRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -162,12 +163,42 @@ class ShopRepositoryTest {
     @DisplayName("데이터 검증[success]: 가게 정보에 상품에 대한 이미지까지 붙였을 때 잘 조회되는 지 테스트 ")
     @Transactional
     public void addCakeImageFileWithShopTest() {
+        //given
         TestDataSize testDataSize = testInitDB.dbInitWithItems();
         //when
         List<Shop> all = shopRepository.findAll(0, 10);
         //then
         Assertions.assertThat(all.size()).isEqualTo(2);
+    }
+    @Test
+    @DisplayName("필드 검증[success]: 가게 정보 생성, 수정 날짜에 대한 검증")
+    @Transactional
+    public void createNewShopWithDate() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        TestDataItem testDataItem = testInitDB.dbInitWithSingleItem();
+        //when
+        Shop shop1 = (Shop) testDataItem.getItems().get("shop1");
+        String phoneNumber = shop1.getPhoneNumber();
 
+        //then
+        Assertions.assertThat(shop1.getCreateAt()).isAfter(now);
+
+    }
+    @Test
+    @DisplayName("필드 검증[success]: 가게의 예약 안내사항 정보 entity 대한 생성 , 수정 날짜에 대한 검증")
+    @Transactional
+    public void createNewShopAndReservationInfoWithDate() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        TestDataItem testDataItem = testInitDB.dbInitWithSingleItem();
+        //when
+        Shop shop1 = (Shop) testDataItem.getItems().get("shop1");
+        ReserveInfo reserveInfo = shop1.getReserveInfo();
+
+        //then
+        Assertions.assertThat(shop1.getCreateAt()).isAfter(now);
+        Assertions.assertThat(reserveInfo.getCreateAt().getMinute()).isEqualTo(now.getMinute());
     }
     @Test
     @DisplayName("비즈니스 로직 검증[success]: 상품 예약 관련, 현장 판매일 경우 다른 옵션들이 디폴트값으로 세팅되어 있는지 테스트")


### PR DESCRIPTION
===========================================================
[기능 추가]
- restTemplate 를 활용하는 api 가 AOP 레벨로 retry 및 예외처리를 할 수 있도록 변경

[기능 개선]
- 각 데이터가 생성되는 날짜, 수정 날짜를 JPA 를 통해 생성할 수 있도록 기능 추가
- JPA config 를 따로 관리하여 WebMockMVC로 테스트를 진행하는 경우, JPA layer에 대한 bean 생성이 불가한 오류 해결

- Api 예외처리 테스트 시, Mock uri builder 를 바꿔치기 어려웠던 문제를 해겷하기 위해 추상화 리팩토링
- 테스트에서 Mock Web Server 와 관련된 클래스들 또한 Mock 생성할 수 있도록 기능 개선
- 테스트를 위해 3rd-party api Dto 생성 메서드 추가

[추후 개선 사항]
- api 관련 예외처리들을 더 강화할 예정
- webclient 의 경우 클래스 분리하여 리팩토링 예정
- retry 관련 예외처리 핸들러 별도로 작성 예정
- api 연동을 하여 제공하는 서비스 계층의 경우, 예외처리에 따른 대응 및 연계 예외처리 필요