### PR TITLE
Feature & Fix: WebClient retry 로직이 제대로 동작하지 않는 문제 수정 및 MSA openapi 기능 추가

### DIFF
--- a/src/main/java/co/pickcake/config/WebClientConfig.java
+++ b/src/main/java/co/pickcake/config/WebClientConfig.java
@@ -32,7 +32,7 @@ public class WebClientConfig {
     public ConnectionProvider connectionProvider() {
         return ConnectionProvider.builder("http-pool")
                 .maxConnections(100)
-                .pendingAcquireTimeout(Duration.ofMillis(0))
+                .pendingAcquireTimeout(Duration.ofMillis(100))
                 .pendingAcquireMaxCount(2)
                 .maxIdleTime(Duration.ofMillis(1000L))
                 .build();

--- a/src/main/java/co/pickcake/mapapi/service/BaseUriBuilder.java
+++ b/src/main/java/co/pickcake/mapapi/service/BaseUriBuilder.java
@@ -7,4 +7,6 @@ import java.net.URI;
 public interface BaseUriBuilder {
     public URI builderUrlByAddress(Address address);
 
+    public URI builderUrlByKeyWord(Double longitude, Double latitude, Double radius, String keyword);
+
 }

--- a/src/main/java/co/pickcake/mapapi/service/KaKaoUriBuilderService.java
+++ b/src/main/java/co/pickcake/mapapi/service/KaKaoUriBuilderService.java
@@ -16,19 +16,26 @@ public class KaKaoUriBuilderService implements BaseUriBuilder  {
 
     /* TODO api url 관리 방법 고민, 지금은 서비스 규모가 크지 않아 static final 로 관리 */
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
+    private static final String KAKAO_LOCAL_KEYWORD_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
 
     @Override
     public URI builderUrlByAddress(Address address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
         uriBuilder.queryParam("query", address.toSimpleString());
-        URI uri = uriBuilder.build().encode().toUri();
-        return uri;
+        return uriBuilder.build().encode().toUri();
     }
-    public URI builderUrlByAddressForTest(Address address) {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl("http://localhost:8080/map/o/v1");
-        uriBuilder.queryParam("query", address.toSimpleString());
-        URI uri = uriBuilder.build().encode().toUri();
-        log.info("[KaKaoUriBuilderService builderByAddressSearch] address: {}, url: {}", address, uri);
-        return uri;
+    @Override
+    public URI builderUrlByKeyWord(Double longitude, Double latitude, Double radius, String keyword) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_KEYWORD_SEARCH_URL);
+        uriBuilder.queryParam("query", keyword);
+        uriBuilder.queryParam("x", longitude);
+        uriBuilder.queryParam("y", latitude);
+        uriBuilder.queryParam("radius", radius*1000);
+        uriBuilder.queryParam("sort", "distance");
+
+        return uriBuilder.build().encode().toUri();
     }
+
+
 }

--- a/src/main/java/co/pickcake/mapapi/service/MapSearchApiService.java
+++ b/src/main/java/co/pickcake/mapapi/service/MapSearchApiService.java
@@ -10,17 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 
@@ -128,7 +124,6 @@ public class MapSearchApiService {
         log.error("[api request failed] check naver api address: {} ", address);
         return null;
     }
-
 
     /* WebClient :: IMPORTANT 외부 api 제공 및 내부에서 연동 api 로 사용하기 위해 따로 생성하였으며 추후 분리 예정 */
 

--- a/src/main/java/co/pickcake/mapapi/service/NaverUriBuilderService.java
+++ b/src/main/java/co/pickcake/mapapi/service/NaverUriBuilderService.java
@@ -21,4 +21,10 @@ public class NaverUriBuilderService implements BaseUriBuilder {
         URI uri = uriBuilder.build().encode().toUri();
         return uri;
     }
+
+    @Override
+    public URI builderUrlByKeyWord(Double longitude, Double latitude, Double radius, String keyword) {
+        return null;
+    }
+
 }

--- a/src/main/java/co/pickcake/reservedomain/searchcake/controller/CakeSearchOpenApi.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/controller/CakeSearchOpenApi.java
@@ -4,31 +4,39 @@ import co.pickcake.reservedomain.searchcake.dto.CakeCategorySearch;
 import co.pickcake.reservedomain.searchcake.dto.CakeSimpleSearch;
 import co.pickcake.reservedomain.searchcake.dto.CakeSimpleSearchRequest;
 import co.pickcake.reservedomain.searchcake.dto.ResultDto;
+import co.pickcake.reservedomain.searchcake.response.PickCakeApiResponse;
+import co.pickcake.reservedomain.searchcake.response.PickCakeDocumentResponse;
+import co.pickcake.reservedomain.searchcake.response.PickCakeMetaResponse;
 import co.pickcake.reservedomain.searchcake.service.CakeSearchService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ROLE_USER')")
 @RequestMapping("/openapi")
-public class CakeSearchOpenAi {
+public class CakeSearchOpenApi {
 
     private final CakeSearchService cakeSearchService;
     @GetMapping("/cake")
-    public ResultDto searchAllCake(
+    public PickCakeApiResponse searchAllCake(
             @Validated @RequestParam(value ="offset", defaultValue = "0") @PositiveOrZero int offset,
             @Validated @RequestParam(value ="limit", defaultValue = "10") int limit) {
         List<CakeSimpleSearch> all = cakeSearchService.findAll(offset, limit);
-        return new ResultDto(all.size(), all);
+        PickCakeMetaResponse meta = PickCakeMetaResponse.create(all.size());
+        List<PickCakeDocumentResponse> collect = all.stream().map(PickCakeDocumentResponse::new).collect(Collectors.toList());
+        return PickCakeApiResponse.create(HttpStatus.OK, meta, collect);
+
     }
     @GetMapping("/cake/call")
     public ResultDto searchCakeCall(@RequestBody @Valid CakeSimpleSearchRequest request) {

--- a/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeApiResponse.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeApiResponse.java
@@ -1,0 +1,25 @@
+package co.pickcake.reservedomain.searchcake.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Data
+public class PickCakeApiResponse {
+    @JsonProperty("status")
+    private HttpStatus status;
+
+    @JsonProperty("meta")
+    private PickCakeMetaResponse metaResponse;
+    @JsonProperty("documents")
+    private List<PickCakeDocumentResponse> documentResponses;
+    public static PickCakeApiResponse create(HttpStatus status, PickCakeMetaResponse meta, List<PickCakeDocumentResponse> documents) {
+        PickCakeApiResponse response = new PickCakeApiResponse();
+        response.status= status;
+        response.metaResponse = meta;
+        response.documentResponses = documents;
+        return response;
+    }
+}

--- a/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeDocumentResponse.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeDocumentResponse.java
@@ -1,0 +1,32 @@
+package co.pickcake.reservedomain.searchcake.response;
+
+import co.pickcake.reservedomain.searchcake.dto.CakeSimpleSearch;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PickCakeDocumentResponse {
+
+    @JsonProperty("item_id")
+    private Long itemId;
+    @JsonProperty("item_name")
+    private String name;
+    @JsonProperty("price")
+    private Integer price;
+
+    public PickCakeDocumentResponse(CakeSimpleSearch o) {
+        itemId = o.getItemId();
+        name = o.getName();
+        price = o.getPrice();
+    }
+    /* 테스트 용으로 만든 생성 메서드 */
+    public PickCakeDocumentResponse(Long id, String name, Integer price) {
+//        PickCakeDocumentResponse response = new PickCakeDocumentResponse();
+        this.itemId = id;
+        this.price = price;
+        this.name = name;
+    }
+
+    private PickCakeDocumentResponse() {
+    }
+}

--- a/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeMetaResponse.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/response/PickCakeMetaResponse.java
@@ -1,0 +1,17 @@
+package co.pickcake.reservedomain.searchcake.response;
+
+import co.pickcake.mapapi.response.KaKaoMetaResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PickCakeMetaResponse {
+    @JsonProperty("total_count")
+    private Integer totalCount;
+
+    public static PickCakeMetaResponse create(Integer totalCount) {
+        PickCakeMetaResponse meta = new PickCakeMetaResponse();
+        meta.totalCount = totalCount;
+        return meta;
+    }
+}

--- a/src/main/java/co/pickcake/reservedomain/searchcake/service/CakeSearchApiRequestService.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/service/CakeSearchApiRequestService.java
@@ -5,10 +5,13 @@ import co.pickcake.aop.apigateway.ApiGatewayConfig;
 import co.pickcake.apiutil.WebClientUtil;
 import co.pickcake.reservedomain.searchcake.dto.CakeSimpleSearch;
 import co.pickcake.reservedomain.searchcake.dto.ResultDto;
+import co.pickcake.reservedomain.searchcake.response.PickCakeApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.net.URI;
 import java.util.List;
 
 @Service
@@ -17,28 +20,21 @@ public class CakeSearchApiRequestService {
 
     private final ApiGatewayConfig apiGatewayConfig;
 
-//    private final WebClientUtil webClientUtil;
-    /* api 요청의 경우, 요청에 대한 응답을 받은 이후 시점에서 예외처리를 해야하기 때문에 더 상세한 고민이 필요
-    * 혹시라도 nob-block 을 쓰거나 async로 소켓 통신하게 되면 반드시 후속 처리를 헤야한다.
-    * TODO 다음과 같은 api call 예외처리 추가 예정
-    *  - session timeout
-    *  - bad gateway
-    *  - session is closed -> 금번 이슈에서 발생하였지만 요청 시 세션이 아닌 다른 fd 로 session close 혹은 commit 이 가는 이슈가 있었음
-    *  - non-block 으로 아직 응답 요청을 받지 못한 체 컨트롤러에서 처리해야할 경우
-    *
-    * */
-    public ResultDto searchCakes(int offset, int limit) {
-        WebClient uploadApi = WebClient.builder()
-                .baseUrl(apiGatewayConfig.getSearchCakeGateWay())
-                .build();
+    /* MSA 로 구현할 경우, 내부 서비스 에 대한 api 요청 서비스 */
+    private final WebClientUtil webClientUtil;
+    private final PickCakeUriBuilderService pickCakeUriBuilderService;
 
-        /*TODO non-block or async & 예외처리 추가 */
-        return uploadApi.get()
-                .uri(apiGatewayConfig.getSearchCakeApi())
-                .retrieve()
-                .bodyToMono(ResultDto.class)
-                .block();
+
+    public PickCakeApiResponse searchCakes(Integer offset, Integer limit) {
+        URI uri = pickCakeUriBuilderService.builderUrlByDefault(offset, limit);
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        return webClientUtil.get(uri, PickCakeApiResponse.class, map);
     }
+
+
+
+
+
 
 
 

--- a/src/main/java/co/pickcake/reservedomain/searchcake/service/PickCakeUriBuilderService.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/service/PickCakeUriBuilderService.java
@@ -1,0 +1,29 @@
+package co.pickcake.reservedomain.searchcake.service;
+
+import co.pickcake.aop.apigateway.ApiGatewayConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PickCakeUriBuilderService {
+    private final ApiGatewayConfig apiGatewayConfig;
+
+    public URI builderUrlByDefault(Integer offset, Integer limit) {
+        String url = apiGatewayConfig.getSearchCakeGateWay() + apiGatewayConfig.getSearchCakeApi();
+        log.info("[pickcake-api uri builder] : {}", url);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(url);
+        uriBuilder.queryParam("offset", offset);
+        uriBuilder.queryParam("limit", limit);
+        return  uriBuilder.build().encode().toUri();
+    }
+
+
+
+}

--- a/src/test/java/co/pickcake/BeanSearchTest.java
+++ b/src/test/java/co/pickcake/BeanSearchTest.java
@@ -1,0 +1,35 @@
+package co.pickcake;
+
+import co.pickcake.config.FileSystemConfig;
+import co.pickcake.mapapi.distance.DistanceAlgorithm;
+import co.pickcake.policies.filename.policy.FileNamePolicy;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+
+
+@TestConfiguration
+public class BeanSearchTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext();
+
+    @Test
+    public void whichConfig() {
+
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String defination : beanDefinitionNames) {
+            System.out.println("defination = " + defination);
+        }
+
+
+
+//        System.out.println("distanceAlgorithm = " + distanceAlgorithm);
+//        System.out.println("fileNamePolicy = " + fileNamePolicy);
+    }
+
+
+}

--- a/src/test/java/co/pickcake/imagedomain/controller/CakeImageStoreApiTest.java
+++ b/src/test/java/co/pickcake/imagedomain/controller/CakeImageStoreApiTest.java
@@ -42,7 +42,7 @@ class CakeImageStoreApiTest {
     private MockMvc mockMvc;
     @MockBean
     private ImageServer imageServer;
-    @MockBean // 확인 필요
+    @MockBean
     private MemberRepository memberRepository;
     @AfterEach
     void clean() {
@@ -67,8 +67,6 @@ class CakeImageStoreApiTest {
         mockMvc.perform(
                 multipart("/api/image/store")
                         .file(storedImage)
-//                        .param("title", "제목1")
-//                        .param("description", "설명설명")
                         .param("storeName", storeName)
         ).andExpect(status().isOk());
 
@@ -92,8 +90,6 @@ class CakeImageStoreApiTest {
         mockMvc.perform(
                 multipart("/api/image/store")
                         .file(storedImage)
-//                        .param("title", "제목1")
-//                        .param("description", "설명설명")
                         .param("storeName", storeName)
         ).andExpect(status().isBadRequest());
 

--- a/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceRetryTest.java
+++ b/src/test/java/co/pickcake/mapapi/service/MapSearchApiServiceRetryTest.java
@@ -56,7 +56,7 @@ public class MapSearchApiServiceRetryTest {
         HttpUrl url = mockWebServer.url("/");
         System.out.println("url = " + url);
         mockWebUriBuilder = new MockWebUriBuilder(); /* 별도로 쿼리 생성해야한다면 이 부분 반드시 바꿀 것 */
-        mockWebUriBuilder.LOCAL_REQEUST_GATE_WAY = mockWebServer.url("/").uri().toString();
+        mockWebUriBuilder.LOCAL_REQUEST_GATE_WAY = mockWebServer.url("/").uri().toString();
     }
     @AfterEach
     void tearDown() {
@@ -72,13 +72,18 @@ public class MapSearchApiServiceRetryTest {
     *   생각했던 것 보다 코드 양이 자꾸 늘어나서 더 최적화된 보일러 플레이트 코드 필요 */
     /* SEE MockWebUriBuilder at BeforeEach */
     public static class MockWebUriBuilder implements BaseUriBuilder  {
-        public String LOCAL_REQEUST_GATE_WAY = "http://localhost";
+        public String LOCAL_REQUEST_GATE_WAY = "http://localhost";
         @Override
         public URI builderUrlByAddress(Address address) {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(LOCAL_REQEUST_GATE_WAY);
+            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(LOCAL_REQUEST_GATE_WAY);
             uriBuilder.queryParam("query", address.toSimpleString());
             URI uri = uriBuilder.build().encode().toUri();
             return uri;
+        }
+
+        @Override
+        public URI builderUrlByKeyWord(Double longitude, Double latitude, Double radius, String keyword) {
+            return null;
         }
     }
     public static class MockWebResponseBuilder {

--- a/src/test/java/co/pickcake/reservedomain/searchcake/controller/CakeSearchOpenApiTest.java
+++ b/src/test/java/co/pickcake/reservedomain/searchcake/controller/CakeSearchOpenApiTest.java
@@ -44,6 +44,20 @@ class CakeSearchOpenApiTest {
     }
 
     @Test
+    @DisplayName("api 검증[success]: 페이징 테스트")
+    void searchCake() throws  Exception {
+        //given
+        ResultActions response = mockMvc.perform(
+                get("/openapi/cake")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"offset\": 0, \"limit\": 10 }")
+        );
+
+        //then
+        response.andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
     @DisplayName("api 검증[success]: 전체 상품을 조회 테스트 ")
     void searchAllCakeTestBody() throws Exception {
         //given

--- a/src/test/java/co/pickcake/reservedomain/searchcake/service/CakeSearchApiRequestServiceTest.java
+++ b/src/test/java/co/pickcake/reservedomain/searchcake/service/CakeSearchApiRequestServiceTest.java
@@ -1,41 +1,129 @@
 package co.pickcake.reservedomain.searchcake.service;
 
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
-import co.pickcake.aop.apigateway.ApiGatewayConfig;
-import co.pickcake.reservedomain.searchcake.dto.ResultDto;
+import co.pickcake.reservedomain.searchcake.response.PickCakeApiResponse;
+import co.pickcake.reservedomain.searchcake.response.PickCakeDocumentResponse;
+import co.pickcake.reservedomain.searchcake.response.PickCakeMetaResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+
 @SpringBootTest
 @WithMockUser(roles = "USER")
+@AutoConfigureMockMvc
 class CakeSearchApiRequestServiceTest {
 
-    @Autowired
-    private  CakeSearchApiRequestService apiRequestService;
+    @Autowired private CakeSearchApiRequestService apiRequestService;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean
+    private PickCakeUriBuilderService pickCakeUriBuilderService;
+    private MockWebServer mockWebServer;
+    private MockWebUriBuilder mockWebUriBuilder;
+    public static class MockWebUriBuilder {
+        public String LOCAL_REQUEST_GATE_WAY = "http://localhost";
+        public URI builderUrlByDefault(Integer offset, Integer limit) {
+            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(LOCAL_REQUEST_GATE_WAY);
+            uriBuilder.queryParam("offset", offset);
+            uriBuilder.queryParam("limit", limit);
+            URI uri = uriBuilder.build().encode().toUri();
+            return uri;
+        }
+    }
+    public static class MockWebResponseBuilder {
+
+        public static PickCakeApiResponse create() {
+            PickCakeMetaResponse metaExpected = PickCakeMetaResponse.create(2);
+            PickCakeDocumentResponse document1 = new PickCakeDocumentResponse(100L, "생크림케이크", 100000);
+            PickCakeDocumentResponse document2 = new PickCakeDocumentResponse(201L, "딸기케이크", 150000);
+            ArrayList<PickCakeDocumentResponse> documentsExpected = new ArrayList<>();
+            documentsExpected.add(document1);
+            documentsExpected.add(document2);
+            return PickCakeApiResponse.create(HttpStatus.OK, metaExpected, documentsExpected);
+        }
+    }
+
 
     @BeforeEach
     void setUp() {
+        mockWebServer = new MockWebServer();
+        try {
+            mockWebServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        int port = mockWebServer.getPort();
+        System.out.println("Mock Web Server port = " + port);
+        HttpUrl url = mockWebServer.url("/");
+        System.out.println("url = " + url);
+        mockWebUriBuilder = new MockWebUriBuilder();
+        mockWebUriBuilder.LOCAL_REQUEST_GATE_WAY = mockWebServer.url("/").uri().toString();
     }
 
     @AfterEach
     void tearDown() {
+        try {
+            mockWebServer.shutdown();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
-    void searchCakesRequestTest() {
-
-//        ResultDto resultDto = apiRequestService.searchCakes(0, 10);
-
-
+    @DisplayName("v1 api[success]: 외부로 나가는 api 검증")
+    void searchCakesRequestTest() throws JsonProcessingException {
+        //given
+        PickCakeApiResponse responseExpected = MockWebResponseBuilder.create();
+        Mockito.when(pickCakeUriBuilderService.builderUrlByDefault(0,10))
+                .thenReturn(mockWebUriBuilder.builderUrlByDefault(0, 10));
+        //when
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseExpected)));
+        PickCakeApiResponse response = apiRequestService.searchCakes(0, 10);
+        //then
+        Assertions.assertThat(response).isNotNull();
+        System.out.println("response = " + response);
+    }
+    @Test
+    @DisplayName("v1 api[success]: retry test")
+    void searchCakesRequestTest2() throws JsonProcessingException {
+        //given
+        PickCakeApiResponse responseExpected = MockWebResponseBuilder.create();
+        Mockito.when(pickCakeUriBuilderService.builderUrlByDefault(0,10))
+                .thenReturn(mockWebUriBuilder.builderUrlByDefault(0, 10));
+        //when
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseExpected)));
+        PickCakeApiResponse response = apiRequestService.searchCakes(0, 10);
+        //then
+        Assertions.assertThat(response).isNotNull();
+        System.out.println("response = " + response);
     }
 }


### PR DESCRIPTION
===========================================================

 [기능 추가]
- pickcake 서비스를 MSA 로 변경 시 일부 api 들에 대한 request & response 처리 대폭 리팩토링

[버그 픽스]
- 주입받는 Webclient 설정 에서 504 에러시 retry 하지 않고 에러 핸들러를 통해 바로 종료하는 문제 수정
- 이제 webclient 도 retry 할 수록 디폴드 수정 반영하였고 Noretry 방식의 GET 요청은 분리 리팩토링

[테스트 강화]
- conifg 가 많아짐에 따라 일부 Bean 은 별도로 테스트 추가
- openapi 관련 Mock server 기반으로 테스트 추가 생성
- retry 관련 예외처리 테스트 추가
- Auth 기능 관련 비즈니스 로직 테스트 추가 반영 (관련 로직을 일부 반영하여 빌드 이슈 있을 수 있음...)