### PR TITLE
Fix: 단건 조회시 service 에서 Optional 로 Dto 감싸서 던지는 문제 해결

### DIFF
--- a/src/main/java/co/pickcake/chatGPT/cache/ChatCPTRedisService.java
+++ b/src/main/java/co/pickcake/chatGPT/cache/ChatCPTRedisService.java
@@ -60,14 +60,14 @@ public class ChatCPTRedisService {
         hashOperations.delete(CACHE_KEY, getSubKey(query));
     }
 
-    public Optional<ChatRecommendResponse> findByQuery(RecommendQuery query) {
+    public ChatRecommendResponse findByQuery(RecommendQuery query) {
         try {
             String result = hashOperations.get(CACHE_KEY, getSubKey(query)); // 여기서 null 내려주면 아래 catch
             ChatRecommendResponse response = deserializeRecommendResponse(result);
-            return Optional.ofNullable(response);
+            return response;
         } catch (Exception e) {
             log.error("[] {}", e.getMessage());
-            return Optional.empty();
+            return new ChatRecommendResponse();
         }
     }
 }

--- a/src/main/java/co/pickcake/chatGPT/service/ChatGPTService.java
+++ b/src/main/java/co/pickcake/chatGPT/service/ChatGPTService.java
@@ -36,10 +36,10 @@ public class ChatGPTService implements GenerateQuestion  {
     )
     public ChatRecommendResponse requestRecommendBart(RecommendQuery query) {
 
-        Optional<ChatRecommendResponse> byQuery = chatCPTRedisService.findByQuery(query);
-        if (byQuery.isPresent()) {
+        ChatRecommendResponse byQuery = chatCPTRedisService.findByQuery(query);
+        if (byQuery.getGivenId() != null) {
             log.info("[Chat GPT recommend] get By Redis");
-            return byQuery.get();
+            return byQuery;
         }
         // use redis -> 추후에 mongo db 교체
         URI uri = chatGPTQueryBuilderService.builderByDefaultQuery(query);

--- a/src/main/java/co/pickcake/reservedomain/searchcake/service/CakeSearchService.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/service/CakeSearchService.java
@@ -59,7 +59,6 @@ public class CakeSearchService {
 
         return collect;
     }
-    /* TODO List 비었을 때 처리 고민 필요 */
     public List<CakeSimpleSearch> findByBrand(int offset, int limit, String brand) {
         Optional<List<Cake>> cakes = Optional.ofNullable(cakeUserRepository.findByBrand(offset, limit, brand));
 

--- a/src/test/java/co/pickcake/chatGPT/service/ChatGPTServiceIntegrationTest.java
+++ b/src/test/java/co/pickcake/chatGPT/service/ChatGPTServiceIntegrationTest.java
@@ -88,10 +88,10 @@ class ChatGPTServiceIntegrationTest extends AbstractIntegrationContainerTest {
 
         //when
         chatCPTRedisService.save(responseExpected, query);
-        Optional<ChatRecommendResponse> responseActual = chatCPTRedisService.findByQuery(query);
+        ChatRecommendResponse responseActual = chatCPTRedisService.findByQuery(query);
         //then
-        Assertions.assertThat(responseActual.isPresent()).isTrue();
-        Assertions.assertThat(responseActual.get().getChooses().getFirst().getContents()).isEqualTo("레드벨벳 케이크");
+        Assertions.assertThat(responseActual.getGivenId()).isNotNull();
+        Assertions.assertThat(responseActual.getChooses().getFirst().getContents()).isEqualTo("레드벨벳 케이크");
 
         //afterEach
         chatCPTRedisService.delete(query);

--- a/src/test/java/co/pickcake/chatGPT/service/ChatGPTServiceUnitTest.java
+++ b/src/test/java/co/pickcake/chatGPT/service/ChatGPTServiceUnitTest.java
@@ -83,7 +83,7 @@ class ChatGPTServiceUnitTest {
                 .build();
 
         //when
-        Mockito.when(chatCPTRedisService.findByQuery(query)).thenReturn(Optional.of(responseExpected));
+        Mockito.when(chatCPTRedisService.findByQuery(query)).thenReturn(responseExpected);
         ChatRecommendResponse responseActual = chatGPTService.requestRecommendBart(query);
         //then
         assertThat(responseActual.getGivenId()).isEqualTo(responseExpected.getGivenId());


### PR DESCRIPTION
======================================================================

[현상 및 원인]
- 외부 api 연동 서비스에서 단건 조회 시 Optional 로 감싸서 Dto 를 넘김으로써 의미없이 method chain 이 길어지는 현상


[코드 오류 해결]
- 연동 api 예외 처리 수정 반영
- 만약 api 연동 호출에 실패했다면 id 를 포함한 빈 Dto를 내려주고 받는 쪽에서 Id 가 비었으면 throw 혹은 Null 처리 할 수 있도록 예외 처리