### PR TITLE
Refactoring: JPA 리팩토링 예정

### DIFF
--- a/src/main/java/co/pickcake/reservedomain/searchcake/repository/CakeRepository.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/repository/CakeRepository.java
@@ -1,0 +1,22 @@
+package co.pickcake.reservedomain.searchcake.repository;
+
+import co.pickcake.reservedomain.entity.item.Cake;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CakeRepository extends JpaRepository<Cake, Long> {
+
+    @Query("select c from Cake c" +
+            " join fetch c.cakeImages ci" +
+            " join fetch ci.profileImage p" +
+            " join fetch  c.shop s" +
+            " join fetch s.reserveInfo ri" +
+            " join fetch s.naver sn" +
+            " join fetch s.instagram sii" +
+            " where c.id = :itemId")
+    Cake findByIdDetails(@Param("itemId") Long id);
+
+}

--- a/src/main/java/co/pickcake/reservedomain/searchcake/repository/CakeRepositoryJpa.java
+++ b/src/main/java/co/pickcake/reservedomain/searchcake/repository/CakeRepositoryJpa.java
@@ -1,9 +1,0 @@
-package co.pickcake.reservedomain.searchcake.repository;
-
-import co.pickcake.reservedomain.entity.item.Cake;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CakeRepositoryJpa extends JpaRepository<Cake, Long> {
-
-
-}

--- a/src/main/java/co/pickcake/shopdomain/entity/Shop.java
+++ b/src/main/java/co/pickcake/shopdomain/entity/Shop.java
@@ -12,12 +12,15 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of = {"id", "shopName", "siteUrl", "address" })
 public class Shop extends AuditOnTime {
 
     @Id @GeneratedValue

--- a/src/test/java/co/pickcake/reservedomain/searchcake/repository/CakeRepositoryJPATest.java
+++ b/src/test/java/co/pickcake/reservedomain/searchcake/repository/CakeRepositoryJPATest.java
@@ -1,0 +1,45 @@
+package co.pickcake.reservedomain.searchcake.repository;
+
+import co.pickcake.authdomain.entity.Member;
+import co.pickcake.reservedomain.entity.item.Cake;
+import co.pickcake.shopdomain.entity.Shop;
+import co.pickcake.testconfig.TestDataItem;
+import co.pickcake.util.TestInitDB;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class CakeRepositoryJPATest {
+
+
+    @Autowired
+    private CakeRepository cakeRepository;
+
+    @Autowired
+    private TestInitDB testInitDB;
+
+    @Test
+    @DisplayName("데이터 검증[success] 아이템 ID 상세페이지  데이터 조회했을 때 결과  ")
+    @Transactional
+    void findByIdDetails() {
+        //given
+        TestDataItem testDataItem = testInitDB.dbInitWithSingleItem();
+        Cake cake1 = (Cake) testDataItem.getItems().get("cake1");
+        Member member1 = (Member) testDataItem.getItems().get("member1");
+        Shop shop = (Shop) testDataItem.getItems().get("shop1");
+        Long toFind = cake1.getId();
+
+        //when
+        Cake byIdDetails = cakeRepository.findByIdDetails(toFind);
+
+        //then
+        Assertions.assertThat(byIdDetails).isNotNull();
+        Assertions.assertThat(byIdDetails.getShop()).isEqualTo(shop);
+
+    }
+}


### PR DESCRIPTION
======================================================================

[리팩토링 사유]
- 순수 JPA 와 스프링 데이터 JPA 가 섞여 있는 문제점
- 서비스 계층과 레포지토리 계층이 도메인 계층(entity) 에 비해 지나치게 커졌음

[리팩토링 방향]
- 정적 쿼리는 스프링 데이터 JPA 로 변환
- 가능한 테이블 조인이 필요하면 도메인 계층으로 쿼리를 옮기기

[TO DO]
- 추후 FK 를 없애고 스키마 분리 예정